### PR TITLE
fix: [PSAAS-24510] previous commit message causing semantic release failure

### DIFF
--- a/whois_connector.py
+++ b/whois_connector.py
@@ -53,7 +53,7 @@ def monkey_patched_whois_request(domain, server, port=43):
     return buff.decode(encoding)
 
 
-# monkey patching internal pythonwhois method that throws decoding error
+# monkey-patching internal pythonwhois method that throws decoding error
 pythonwhois.net.whois_request = monkey_patched_whois_request
 
 


### PR DESCRIPTION
### Bug Fixes
previous commit message causing semantic release failure

- [ ✅ ] I have verified that manual documentation has been updated where appropriate
